### PR TITLE
Adding support for NULL values

### DIFF
--- a/src/EMysqliStmt.php
+++ b/src/EMysqliStmt.php
@@ -161,6 +161,11 @@ class EMysqliStmt extends mysqli_stmt
 	 */
 	private function prepareValue($value, $type)
 	{
+		if ($value === NULL)
+		{
+			return 'NULL';
+		}
+
 		if ('i' === $type) {
 			return (int) $value;
 		}


### PR DESCRIPTION
When bound value is NULL, mysqli will send an SQL NULL value. While this lib will make an empty string in in the query. So to make it consistent and compatible it should be NULL as well.